### PR TITLE
enumerate the commenter names

### DIFF
--- a/PP.js
+++ b/PP.js
@@ -59,6 +59,18 @@ if(window.location.hostname != "pubpeer.com" && pageDOIs.length > 0){
 			} else if(total_comments > 1){
 				hrefText = total_comments + " comments on PubPeer";
 			}
+			if(total_comments > 0) {
+				let comment_users = "by ";
+				for(let j = 0; j < total_comments; j++) {
+					if(json.feedbacks[i].comments[j] && json.feedbacks[i].comments[j].user) {
+						comment_users += json.feedbacks[i].comments[j].user;
+						if(j+1 < total_comments) {
+							comment_users += ", ";
+						}
+					}
+				}
+				hrefText += " (" + comment_users + ")";
+			}
 			let linkToComments = json.feedbacks[i].url + "?utm_source=Chrome&utm_medium=BrowserExtension&utm_campaign=Chrome";
 			let tagElements = ":contains("+matchedPageDOIs[i]+")";
 			let unsortedDoiElements = $(tagElements);

--- a/manifest.json
+++ b/manifest.json
@@ -19,5 +19,5 @@
      "storage"
    ],
    "name": "PubPeer",
-   "version": "0.2.0"
+   "version": "0.2.1"
 }


### PR DESCRIPTION
as discussed in email, I added a preview of the user names of the commenters. This way comments by e.g. Statcheck will have less urgency than real criticisms by human commenters.
